### PR TITLE
Fix param sharing

### DIFF
--- a/mqgo/src/meqa/mqgo/main.go
+++ b/mqgo/src/meqa/mqgo/main.go
@@ -50,7 +50,8 @@ func getConfigs(meqaPath string) (map[string]interface{}, error) {
 	configPath := filepath.Join(meqaPath, configFile)
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		configMap[configAPIKey] = uuid.NewV4().String()
+		u, _ := uuid.NewV4()
+		configMap[configAPIKey] = u.String()
 		err = writeConfigFile(configPath, configMap)
 		if err != nil {
 			return nil, err

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -1064,7 +1064,8 @@ func generateString(s *spec.Schema, prefix string) (string, error) {
 		return t.Format("2006-01-02"), nil
 	}
 	if s.Format == "uuid" {
-		return uuid.NewV4().String(), nil
+		u, err := uuid.NewV4()
+		return u.String(), err
 	}
 
 	// If no pattern is specified, we use the field name + some numbers as pattern

--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -180,10 +180,18 @@ func GeneratePathTestSuite(operations mqswag.NodeList, plan *TestPlan) {
 	sort.Sort(operations)
 	testId := 0
 	testSuite := CreateTestSuite(fmt.Sprintf("%s", pathName), nil, plan)
+	createTest := &Test{}
+	idTag := "id"
 	for _, o := range operations {
 		testId++
-		testSuite.Tests = append(testSuite.Tests, CreateTestFromOp(o, testId))
-
+		currentTest := CreateTestFromOp(o, testId)
+		testSuite.Tests = append(testSuite.Tests, currentTest)
+		if OperationMatches(o, mqswag.MethodPost) {
+			createTest = currentTest
+		} else if strings.Contains(o.GetName(), idTag) {
+			currentTest.PathParams = make(map[string]interface{})
+			currentTest.PathParams[idTag] = fmt.Sprintf("{{%s.outputs.%s}}", createTest.Name, idTag)
+		}
 		if OperationMatches(o, mqswag.MethodDelete) {
 			lastTest := testSuite.Tests[len(testSuite.Tests)-1]
 			// Find an operation that takes the same last path param.


### PR DESCRIPTION
Once an object gets created via POST, pass its ID to subsequent GET/PUT/DELETE requests