### PR TITLE
Generate all tests if no whitelist file is specified

### DIFF
--- a/mqgo/src/meqa/mqgen/main.go
+++ b/mqgo/src/meqa/mqgen/main.go
@@ -44,7 +44,7 @@ func run(meqaPath *string, swaggerFile *string, algorithm *string, verbose *bool
 		os.Exit(1)
 	}
 	whitelistPath := *whitelistFile
-	whitelist := make(map[string]bool)
+	var whitelist map[string]bool
 	if len(whitelistPath) > 0 {
 		if fi, err := os.Stat(whitelistPath); os.IsNotExist(err) || fi.Mode().IsDir() {
 			fmt.Printf("Can't load whitelist file at the following location %s", whitelistPath)

--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -291,7 +291,7 @@ parameters by default.
 	sort.Sort(pathWeightList)
 
 	for _, p := range pathWeightList {
-		if whitelist[p.path] {
+		if whitelist == nil || whitelist[p.path] {
 			GeneratePathTestSuite(pathMap[p.path], testPlan)
 		}
 	}


### PR DESCRIPTION
The previous implementation always expects a `whitelist.txt`. 
If no such file is specified, assume all endpoints have to be tested.