### PR TITLE
Prevent a post request after delete

### DIFF
--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -198,7 +198,9 @@ func GeneratePathTestSuite(operations mqswag.NodeList, plan *TestPlan) {
 			lastParam := GetLastPathParam(o.GetName())
 			if len(lastParam) > 0 {
 				for _, repeatOp := range operations {
-					if lastParam == GetLastPathParam(repeatOp.GetName()) && !OperationMatches(repeatOp, mqswag.MethodDelete) {
+					if lastParam == GetLastPathParam(repeatOp.GetName()) &&
+						!OperationMatches(repeatOp, mqswag.MethodDelete) &&
+						!OperationMatches(repeatOp, mqswag.MethodPost) {
 						testId++
 						repeatTest := CreateTestFromOp(repeatOp, testId)
 						repeatTest.PathParams = make(map[string]interface{})


### PR DESCRIPTION
After deleting an object, we perform another request on the object and assert it fails.
We have to ensure we don't perform a POST after the DELETE as it would succeed.