### PR TITLE
Data assertions

### DIFF
--- a/mqgo/src/meqa/mqgen/main.go
+++ b/mqgo/src/meqa/mqgen/main.go
@@ -44,7 +44,7 @@ func run(meqaPath *string, swaggerFile *string, algorithm *string, verbose *bool
 		os.Exit(1)
 	}
 	whitelistPath := *whitelistFile
-	whitelist := make(map[string]bool)
+	var whitelist map[string]bool
 	if len(whitelistPath) > 0 {
 		if fi, err := os.Stat(whitelistPath); os.IsNotExist(err) || fi.Mode().IsDir() {
 			fmt.Printf("Can't load whitelist file at the following location %s", whitelistPath)

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -1377,7 +1377,8 @@ func (t *Test) GenerateSchema(name string, parentTag *mqswag.MeqaTag, schema *sp
 	}
 
 	if len(schema.Type) == 0 {
-		return nil, mqutil.NewError(mqutil.ErrInvalid, "Parameter doesn't have type")
+		// return nil, mqutil.NewError(mqutil.ErrInvalid, "Parameter doesn't have type")
+		return t.generateObject(name, tag, schema, db, level)
 	}
 	if schema.Type[0] == gojsonschema.TYPE_OBJECT {
 		return t.generateObject(name, tag, schema, db, level)

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -165,6 +165,7 @@ func (t *Test) Duplicate() *Test {
 	test.resp = nil
 	test.comparisons = make(map[string]([]*Comparison))
 	test.err = nil
+	test.db = test.suite.db
 
 	return &test
 }
@@ -606,6 +607,12 @@ func (t *Test) ProcessResult(resp *resty.Response) error {
 						}
 					}
 				}
+			}
+		}
+		for className, resultArray := range collection {
+			objTag := mqswag.MeqaTag{className, "", "", 0}
+			for _, c := range resultArray {
+				t.AddObjectComparison(&objTag, c.(map[string]interface{}), (*spec.Schema)(t.db.GetSchema(className)))
 			}
 		}
 	}

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -917,7 +917,9 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 			}
 
 			// If there is a parameter passed in, just use it. Otherwise generate one.
-			if paramsMap[params.Name] == nil && globalParamsMap[params.Name] != nil {
+			_, inLocal := paramsMap[params.Name]
+			_, inGlobal := globalParamsMap[params.Name]
+			if !inLocal && inGlobal {
 				paramsMap[params.Name] = globalParamsMap[params.Name]
 			}
 			if _, ok := paramsMap[params.Name]; ok {

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -936,9 +936,11 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 	for _, m := range paramMaps {
 		removeNulls(m)
 	}
-	bodyMap := t.BodyParams.(map[string]interface{})
-	removeNulls(&bodyMap)
-	t.BodyParams = bodyMap
+	if t.BodyParams != nil {
+		bodyMap := t.BodyParams.(map[string]interface{})
+		removeNulls(&bodyMap)
+		t.BodyParams = bodyMap
+	}
 	return nil
 }
 

--- a/mqgo/src/meqa/mqplan/dsl.go
+++ b/mqgo/src/meqa/mqplan/dsl.go
@@ -932,7 +932,24 @@ func (t *Test) ResolveParameters(tc *TestSuite) error {
 			return err
 		}
 	}
+	paramMaps := []*map[string]interface{}{&t.PathParams, &t.QueryParams, &t.HeaderParams, &t.FormParams}
+	for _, m := range paramMaps {
+		removeNulls(m)
+	}
+	bodyMap := t.BodyParams.(map[string]interface{})
+	removeNulls(&bodyMap)
+	t.BodyParams = bodyMap
 	return nil
+}
+
+func removeNulls(inputMap *map[string]interface{}) {
+	filteredMap := make(map[string]interface{})
+	for k, v := range *inputMap {
+		if v != nil {
+			filteredMap[k] = v
+		}
+	}
+	*inputMap = filteredMap
 }
 
 func GetOperationByMethod(item *spec.PathItem, method string) *spec.Operation {

--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -293,7 +293,7 @@ parameters by default.
 	sort.Sort(pathWeightList)
 
 	for _, p := range pathWeightList {
-		if whitelist[p.path] {
+		if whitelist == nil || whitelist[p.path] {
 			GeneratePathTestSuite(pathMap[p.path], testPlan)
 		}
 	}

--- a/mqgo/src/meqa/mqplan/gen.go
+++ b/mqgo/src/meqa/mqplan/gen.go
@@ -198,7 +198,9 @@ func GeneratePathTestSuite(operations mqswag.NodeList, plan *TestPlan) {
 			lastParam := GetLastPathParam(o.GetName())
 			if len(lastParam) > 0 {
 				for _, repeatOp := range operations {
-					if lastParam == GetLastPathParam(repeatOp.GetName()) && !OperationMatches(repeatOp, mqswag.MethodDelete) {
+					if lastParam == GetLastPathParam(repeatOp.GetName()) &&
+						!OperationMatches(repeatOp, mqswag.MethodDelete) &&
+						!OperationMatches(repeatOp, mqswag.MethodPost) {
 						testId++
 						repeatTest := CreateTestFromOp(repeatOp, testId)
 						repeatTest.PathParams = make(map[string]interface{})

--- a/mqgo/src/meqa/mqplan/plan.go
+++ b/mqgo/src/meqa/mqplan/plan.go
@@ -255,7 +255,7 @@ func (plan *TestPlan) LogErrors() {
 		}
 		if t.schemaError != nil {
 			fmt.Print(mqutil.YELLOW)
-			fmt.Println(t.schemaError.Error())
+			// fmt.Println(t.schemaError.Error())
 			fmt.Print(mqutil.END)
 		}
 	}

--- a/mqgo/src/meqa/mqswag/db.go
+++ b/mqgo/src/meqa/mqswag/db.go
@@ -157,7 +157,7 @@ func (schema *Schema) Parses(name string, object interface{}, collection map[str
 	} else if k == reflect.Map {
 		isProperty = false
 		objMap, objIsMap := object.(map[string]interface{})
-		if !objIsMap || !schema.Type.Contains(gojsonschema.TYPE_OBJECT) {
+		if !objIsMap { // || !schema.Type.Contains(gojsonschema.TYPE_OBJECT) {
 			return raiseError("schema is not an object")
 		}
 		for _, requiredName := range schema.Required {

--- a/mqgo/src/meqa/mqutil/map.go
+++ b/mqgo/src/meqa/mqutil/map.go
@@ -176,7 +176,7 @@ func InterfaceEquals(criteria interface{}, existing interface{}) bool {
 			return true
 		} else {
 			existingKind := reflect.TypeOf(existing).Kind()
-			if existingKind == reflect.Map || existingKind == reflect.Array {
+			if existingKind == reflect.Map || existingKind == reflect.Array || existingKind == reflect.Slice {
 				return true
 			}
 			return false
@@ -223,6 +223,9 @@ func InterfaceEquals(criteria interface{}, existing interface{}) bool {
 			}
 		}
 		return true
+	}
+	if eKind == reflect.String && (cKind == reflect.Int || cKind == reflect.Float32 || cKind == reflect.Float64) {
+		return reflect.TypeOf(existing).String() == "json.Number"
 	}
 
 	cJson, _ := json.Marshal(criteria)


### PR DESCRIPTION
Add content/data assertions:
- Common fields between request and response should match
  - For POST and PUT requests
  - Arrays are not compared
- Assertions across requests
  - Responses of POST and subsequent GET should match
  - After a POST request, the object is added to the test suite's in-mem db
  - During GET, the object in the db is searched against the returned results

Changes:
- Original implementation checked every returned result against the db. This would fail for endpoints which list objects.
So modified to check db objects against returned results.
But if there are multiple objects in db (possible if a single POST creates multiple objects) and we query for a single object, it would fail.
- Test db was global. Helps when there's cross-suite dependency (ie. One object takes a previously created object). But we're deleting the object in the end of every suite.
So changed db scope to the respective test suite
- Body parameters are first randomly generated then replaced with values provided. This caused incorrect data to be added to the in-mem db.
Modified to prevent generation if the parameter is provided.
- When an object is created using its `CreateDefinition` and the response contains `ObjectModel` which is a combination of `CreateDefinition` and `MetadataModel`, only the `CreateDefinition` is added to db.
Modified to add all definitions/models to db for later assertions.

@yingxie3 could you review these changes? There might be a reason why these haven't been implemented earlier.
